### PR TITLE
Remove warning for fallback_element_size altogether

### DIFF
--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -351,7 +351,6 @@ function element_size(a::AbstractArray)
     elseif isbitstype(Base.nonmissingtype(eltype(a)))
         return sizeof(Base.nonmissingtype(eltype(a)))
     else
-        @warn "Can not determine size of element type. Using DiskArrays.fallback_element_size[] = $(fallback_element_size[]) bytes" maxlog=1
         return fallback_element_size[]
     end
 end


### PR DESCRIPTION
As a solution to #208 I would suggest to completely remove the warning about fallback element sizes. Alternatively we could also switch to using `@debug` loglevel instead of `@warn`