### PR TITLE
add isdisk method

### DIFF
--- a/src/diskarray.jl
+++ b/src/diskarray.jl
@@ -8,6 +8,15 @@ n-dimensional (hyper)-rectangles.
 abstract type AbstractDiskArray{T,N} <: AbstractArray{T,N} end
 
 """
+    isdisk(a::AbstractArray)
+
+Return `true` if `a` is a `AbstractDiskArray` or follows 
+the DiskArrays.jl interface via macros. Otherwise `false`.
+"""
+isdisk(a::AbstractDiskArray) = true
+isdisk(a::AbstractArray) = false
+
+"""
     readblock!(A::AbstractDiskArray, A_ret, r::AbstractUnitRange...)
 
 The only function that should be implemented by a `AbstractDiskArray`. This function
@@ -367,6 +376,7 @@ include("chunks.jl")
 macro implement_getindex(t)
     t = esc(t)
     quote
+        isdisk(a::$t) = true
         Base.getindex(a::$t, i...) = getindex_disk(a, i...)
         @inline Base.getindex(a::$t, i::ChunkIndex{<:Any,OneBasedChunks}) =
             a[eachchunk(a)[i.I]...]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,6 +35,12 @@ end
     @test a[CartesianIndex(1,2),3] == 15
     @test a[CartesianIndex(1,2,3)] == 15
 end
+@testset "isdisk" begin
+    a = reshape(1:24, 2, 3, 4)
+    da = AccessCountDiskArray(a; chunksize=(2, 2, 2))
+    @test DiskArrays.isdisk(da)
+    @test !DiskArrays.isdisk(a)
+end
 
 @testset "getindex with empty array" begin
     a = AccessCountDiskArray(reshape(1:24,2,3,4),chunksize=(2,2,2))


### PR DESCRIPTION
With the macros its not so easy to know if an array is acutally DiskArrays.jl compliant. This `isdisk` trait fixes that.

Its applied to `AbstractDiskArray` but also in the `getindex` macro to catch non inheriting disk arrays.