### PR TITLE
allow_scalar => allowscalar

### DIFF
--- a/src/scalar.jl
+++ b/src/scalar.jl
@@ -1,29 +1,26 @@
 # Manual control over scalar indexing
-const ALLOW_SCALAR = Ref{Bool}(true)
+const ALLOWSCALAR = Ref{Bool}(true)
 
 """
-    allow_scalar(x::Bool)
+    allowscalar(x::Bool)
 
 Specify if a disk array can do scalar indexing, (with all `Int` arguments).
 
-Setting `allow_scalar(false)` can help identify the cause of poor performance.
+Setting `allowscalar(false)` can help identify the cause of poor performance.
 """
-allow_scalar(x::Bool) = ALLOW_SCALAR[] = x
+allowscalar(x::Bool) = ALLOWSCALAR[] = x
 
 """
-    can_scalar()
+    canscalar()
 
-Check if DiskArrays is set to allow scalar indexing, with [`allow_scalar`](@ref).
+Check if DiskArrays is set to allow scalar indexing, with [`allowscalar`](@ref).
 
 Returns a `Bool`.
 """
-can_scalar() = ALLOW_SCALAR[]
+canscalar() = ALLOWSCALAR[]
 
-function _scalar_error()
-    return error(
-        "Scalar indexing with `Int` is very slow, and currently is disallowed. Run DiskArrays.allow_scalar(true) to allow",
-    )
-end
+@deprecate allow_scalar allowscalar
+@deprecate can_scalar canscalar
 
 # Checks if an index is scalar at all, and then if scalar indexing is allowed. 
 # Syntax as for `checkbounds`.
@@ -31,3 +28,9 @@ checkscalar(::Type{Bool}, I::Tuple) = checkscalar(Bool, I...)
 checkscalar(::Type{Bool}, I...) = !all(map(i -> i isa Int, I)) || can_scalar()
 checkscalar(I::Tuple) = checkscalar(I...)
 checkscalar(I...) = checkscalar(Bool, I...) || _scalar_error()
+
+function _scalar_error()
+    return error(
+        "Scalar indexing with `Int` is very slow, and currently is disallowed. Run DiskArrays.allowscalar(true) to allow",
+    )
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,12 +19,12 @@ if VERSION >= v"1.9.0"
     Aqua.test_deps_compat(DiskArrays)
 end
 
-@testset "allow_scalar" begin
-    DiskArrays.allow_scalar(false)
+@testset "allowscalar" begin
+    DiskArrays.allowscalar(false)
     @test DiskArrays.can_scalar() == false
     @test DiskArrays.checkscalar(Bool, 1, 2, 3) == false
     @test DiskArrays.checkscalar(Bool, 1, 2:5, :) == true
-    DiskArrays.allow_scalar(true)
+    DiskArrays.allowscalar(true)
     @test DiskArrays.can_scalar() == true
     @test DiskArrays.checkscalar(Bool, 1, 2, 3) == true
     @test DiskArrays.checkscalar(Bool, :, 2:5, 3) == true
@@ -72,11 +72,11 @@ function test_getindex(a)
     # Test that readblock was called exactly onces for every getindex
     @test a[2:2:4, 1:2:5] == [2 10 18; 4 12 20]
     @test a[[1, 3, 4], [1, 3], 1] == [1 9; 3 11; 4 12]
-    @testset "allow_scalar" begin
-        DiskArrays.allow_scalar(false)
+    @testset "allowscalar" begin
+        DiskArrays.allowscalar(false)
         @test_throws ErrorException a[2, 3, 1]
         @test_throws ErrorException a[5]
-        DiskArrays.allow_scalar(true)
+        DiskArrays.allowscalar(true)
         @test a[2, 3, 1] == 10
         @test a[5] == 5
     end


### PR DESCRIPTION
I put in an underscore originally but CUDA uses `allowscalar`. 

Its better if theyre the same. `allow_scalar` still works but is deprecated