### PR TITLE
bugfix and improve `isdisk`

### DIFF
--- a/src/diskarray.jl
+++ b/src/diskarray.jl
@@ -13,8 +13,9 @@ abstract type AbstractDiskArray{T,N} <: AbstractArray{T,N} end
 Return `true` if `a` is a `AbstractDiskArray` or follows 
 the DiskArrays.jl interface via macros. Otherwise `false`.
 """
-isdisk(a::AbstractDiskArray) = true
-isdisk(a::AbstractArray) = false
+isdisk(a::AbstractDiskArray) = isdisk(typeof(a))
+isdisk(::Type{<:AbstractDiskArray}) = true
+isdisk(::Type{<:AbstractArray}) = false
 
 """
     readblock!(A::AbstractDiskArray, A_ret, r::AbstractUnitRange...)
@@ -376,7 +377,7 @@ include("chunks.jl")
 macro implement_getindex(t)
     t = esc(t)
     quote
-        isdisk(a::$t) = true
+        DiskArrays.isdisk(::Type{<:$t}) = true
         Base.getindex(a::$t, i...) = getindex_disk(a, i...)
         @inline Base.getindex(a::$t, i::ChunkIndex{<:Any,OneBasedChunks}) =
             a[eachchunk(a)[i.I]...]

--- a/src/diskarray.jl
+++ b/src/diskarray.jl
@@ -13,7 +13,7 @@ abstract type AbstractDiskArray{T,N} <: AbstractArray{T,N} end
 Return `true` if `a` is a `AbstractDiskArray` or follows 
 the DiskArrays.jl interface via macros. Otherwise `false`.
 """
-isdisk(a::AbstractDiskArray) = isdisk(typeof(a))
+isdisk(a::AbstractArray) = isdisk(typeof(a))
 isdisk(::Type{<:AbstractDiskArray}) = true
 isdisk(::Type{<:AbstractArray}) = false
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -890,6 +890,7 @@ struct TestArray{T,N} <: AbstractArray{T,N} end
     DiskArrays.@implement_permutedims TestArray
     DiskArrays.@implement_subarray TestArray
     DiskArrays.@implement_diskarray TestArray
+    @test DiskArrays.isdisk(TestArray) == true
 end
 
 # issue #123


### PR DESCRIPTION
The macro was not applying `isdisk` properly, and it really should be on the type.