### PR TITLE
fast path for common_chunks where only one disk array

### DIFF
--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -60,26 +60,24 @@ function common_chunks(s, args...)
     if isempty(chunkedarrays)
         totalsize = sum(sizeof ∘ eltype, args)
         return estimate_chunksize(s, totalsize)
+    elseif length(chunkedarrays) == 1
+        return eachchunk(only(chunkedarrays))
     else
-        if length(chunkedarrays) > 1
-            allchunks = collect(map(eachchunk, chunkedarrays))
-            tt = ntuple(N) do n
-                csnow = filter(allchunks) do cs
-                ndims(cs) >= n && first(first(cs.chunks[n])) < last(last(cs.chunks[n]))
-                end
-                isempty(csnow) && return RegularChunks(1, 0, s[n])
-                
-                cs = first(csnow).chunks[n]
-                if all(s -> s.chunks[n] == cs, csnow)
-                    return cs
-                else
-                    return merge_chunks(csnow, n)
-                end
+        allchunks = collect(map(eachchunk, chunkedarrays))
+        tt = ntuple(N) do n
+            csnow = filter(allchunks) do cs
+            ndims(cs) >= n && first(first(cs.chunks[n])) < last(last(cs.chunks[n]))
             end
-            GridChunks(tt...)
-        else
-            eachchunk(only(chunkedarrays))
+            isempty(csnow) && return RegularChunks(1, 0, s[n])
+            
+            cs = first(csnow).chunks[n]
+            if all(s -> s.chunks[n] == cs, csnow)
+                return cs
+            else
+                return merge_chunks(csnow, n)
+            end
         end
+        return GridChunks(tt...)
     end
 end
 

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -61,9 +61,9 @@ function common_chunks(s, args...)
         totalsize = sum(sizeof ∘ eltype, args)
         return estimate_chunksize(s, totalsize)
     else
-        tt = if length(chunkedarrays) > 1
+        if length(chunkedarrays) > 1
             allchunks = collect(map(eachchunk, chunkedarrays))
-            ntuple(N) do n
+            tt = ntuple(N) do n
                 csnow = filter(allchunks) do cs
                 ndims(cs) >= n && first(first(cs.chunks[n])) < last(last(cs.chunks[n]))
                 end

--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -38,6 +38,8 @@ function Base.getindex(r::RegularChunks, i::Int)
 end
 Base.size(r::RegularChunks, _) = div(r.s + r.offset - 1, r.cs) + 1
 Base.size(r::RegularChunks) = (size(r, 1),)
+Base.:(==)(r1::RegularChunks, r2::RegularChunks) =
+    r1.cs == r2.cs && r1.offset == r2.offset && r1.s == r2.s
 
 # DiskArrays interface
 
@@ -135,6 +137,9 @@ function Base.getindex(r::IrregularChunks, i::Int)
     return (r.offsets[i] + 1):r.offsets[i + 1]
 end
 Base.size(r::IrregularChunks) = (length(r.offsets) - 1,)
+Base.:(==)(r1::IrregularChunks, r2::IrregularChunks) =
+    r1 === r2 || r1.offsets == r2.offsets
+
 function subsetchunks(r::IrregularChunks, subs::UnitRange)
     c1 = findchunk(r, first(subs))
     c2 = findchunk(r, last(subs))

--- a/src/chunks.jl
+++ b/src/chunks.jl
@@ -38,8 +38,28 @@ function Base.getindex(r::RegularChunks, i::Int)
 end
 Base.size(r::RegularChunks, _) = div(r.s + r.offset - 1, r.cs) + 1
 Base.size(r::RegularChunks) = (size(r, 1),)
-Base.:(==)(r1::RegularChunks, r2::RegularChunks) =
-    r1.cs == r2.cs && r1.offset == r2.offset && r1.s == r2.s
+function Base.:(==)(r1::RegularChunks, r2::RegularChunks)
+    # The axis sizes must always match
+    r1.s == r2.s || return false
+    # The number of chunks must also match
+    nchunks = length(r1)
+    nchunks == length(r2) || return false
+    # But after that we need to take the number of chunks into account
+    if nchunks > 2 
+        # For longer RegularChunks the offsets and chunk sizes 
+        # must match for the chunks to be the same. 
+        # So we compare them directly rather than iterating all of the ranges
+        return r1.cs == r2.cs && r1.offset == r2.offset
+    elseif nchunks == 2
+        # Smaller RegularChunks can match with different chunk sizes and offsets
+        # So we compare the ranges
+        return first(r1) == first(r2) && last(r1) == last(r2)
+    elseif nchunks == 1
+        return first(r1) == first(r2)
+    else
+        return true
+    end
+end
 
 # DiskArrays interface
 


### PR DESCRIPTION
Closes #222

At least for the case of a single disk array, the profile is back to being all GDAL reads.

However it can still be slow for multiple GDAL style column chunked arrays.