### PR TITLE
always allow scalar indexing for zero dimensional

### DIFF
--- a/src/scalar.jl
+++ b/src/scalar.jl
@@ -24,6 +24,7 @@ canscalar() = ALLOWSCALAR[]
 
 # Checks if an index is scalar at all, and then if scalar indexing is allowed. 
 # Syntax as for `checkbounds`.
+checkscalar(::Type{Bool}) = true # Handle 0 dimensional
 checkscalar(::Type{Bool}, I::Tuple) = checkscalar(Bool, I...)
 checkscalar(::Type{Bool}, I...) = !all(map(i -> i isa Int, I)) || canscalar()
 checkscalar(I::Tuple) = checkscalar(I...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,10 +21,12 @@ end
 @testset "allowscalar" begin
     DiskArrays.allowscalar(false)
     @test DiskArrays.canscalar() == false
+    @test DiskArrays.checkscalar(Bool) == true # Always allowed for zero dimensional
     @test DiskArrays.checkscalar(Bool, 1, 2, 3) == false
     @test DiskArrays.checkscalar(Bool, 1, 2:5, :) == true
     DiskArrays.allowscalar(true)
     @test DiskArrays.canscalar() == true
+    @test DiskArrays.checkscalar(Bool) == true
     @test DiskArrays.checkscalar(Bool, 1, 2, 3) == true
     @test DiskArrays.checkscalar(Bool, :, 2:5, 3) == true
     a = AccessCountDiskArray(reshape(1:24, 2, 3, 4), chunksize=(2, 2, 2))


### PR DESCRIPTION
tiny change so we dont get scalar indexing errors on zero dimensional arrays with `A[]`