### PR TITLE
Allow missing elements when constructing ConcatDiskArrays

### DIFF
--- a/src/DiskArrays.jl
+++ b/src/DiskArrays.jl
@@ -13,7 +13,7 @@ using Base: tail
     read(path, String)
 end DiskArrays
 
-export AbstractDiskArray, eachchunk, ChunkIndex, ChunkIndices
+export AbstractDiskArray, eachchunk, ChunkIndex, ChunkIndices, MissingTile
 
 include("scalar.jl")
 include("chunks.jl")

--- a/src/cat.jl
+++ b/src/cat.jl
@@ -5,7 +5,11 @@
     ConcatDiskArray(arrays)
 
 Joins multiple `AbstractArray`s or `AbstractDiskArray`s into
-a single disk array, using lazy concatination.
+a single disk array, using lazy concatination. Note that if some elements
+of `arrays` are `missing`, this array will be interpreted as a block containing 
+only missing elements. This can be useful when concatenating mosaics of tiles 
+where some tiles in are missing or when stacking arrays along a new dimension
+and some layers are missing. 
 
 Returned from `cat` on disk arrays. 
 

--- a/src/cat.jl
+++ b/src/cat.jl
@@ -8,7 +8,7 @@ a single disk array, using lazy concatination. Note that if some elements
 of `arrays` are `missing`, this array will be interpreted as a block containing 
 only missing elements. This can be useful when concatenating mosaics of tiles 
 where some tiles in are missing or when stacking arrays along a new dimension
-and some layers are missing. 
+and some layers are missing.
 
 Returned from `cat` on disk arrays. 
 

--- a/src/cat.jl
+++ b/src/cat.jl
@@ -1,16 +1,15 @@
 """
     ConcatDiskArray <: AbstractDiskArray
-    
+
     ConcatDiskArray(arrays)
 
 Joins multiple `AbstractArray`s or `AbstractDiskArray`s into
-a single disk array, using lazy concatination. Note that if some elements
-of `arrays` are `missing`, this array will be interpreted as a block containing 
-only missing elements. This can be useful when concatenating mosaics of tiles 
-where some tiles in are missing or when stacking arrays along a new dimension
-and some layers are missing.
+a single disk array, using lazy concatenation. If some elements of `arrays`
+are `MissingTile`, the corresponding tile positions will return `fillvalue` when
+read. This is useful when concatenating mosaics of tiles where some tiles are
+missing or when stacking arrays along a new dimension and some layers are absent.
 
-Returned from `cat` on disk arrays. 
+Returned from `cat` on disk arrays.
 
 It is also useful on its own as it can easily concatenate an array of disk arrays.
 """
@@ -23,19 +22,13 @@ struct ConcatDiskArray{T,N,P,C,HC,ID} <: AbstractDiskArray{T,N}
     innerdims::Val{ID}
 end
 
-function ConcatDiskArray(arrays::AbstractArray{Union{<:AbstractArray,Missing}})
-    et = Base.nonmissingtype(eltype(arrays))
-    T = Union{Missing,eltype(et)}
-    N = ndims(arrays)
-    M = ndims(et)
-    _ConcatDiskArray(arrays, T, Val(N), Val(M))
-end
-
 function infer_eltypes(arrays)
     foldl(arrays, init=(-1, Union{})) do (M, T), a
         if a isa AbstractArray
             M == -1 || ndims(a) == M || throw(ArgumentError("All arrays to concatenate must have equal ndims"))
             M = ndims(a)
+        elseif a === missing
+            throw(ArgumentError("Cannot concatenate arrays containing missing values. Use MissingTile(fillvalue) to mark a tile as missing."))
         end
             (M, promote_type(eltype(a), T))
         end
@@ -78,13 +71,17 @@ function ConcatDiskArray(arrays1::AbstractArray, T, ::Val{D},::Val{ID}) where {D
     return ConcatDiskArray{T,D,typeof(arrays1),typeof(chunks),typeof(hc),ID}(arrays1, startinds, sizes, chunks, hc,Val(ID))
 end
 
-struct MissingTile{F}
+struct MissingTile{F,S}
     fillvalue::F
+    size::S
 end
-Base.eltype(::Type{MissingTile{F}}) where F = F
+MissingTile(fillvalue::F) where F = MissingTile{F,Nothing}(fillvalue, nothing)
+MissingTile(fillvalue::F, size::NTuple{N,<:Integer}) where {F,N} =
+    MissingTile{F,typeof(size)}(fillvalue, size)
+Base.eltype(::Type{MissingTile{F,S}}) where {F,S} = F
 
 function extenddims(a::Tuple{Vararg{Any,N}}, b::Tuple{Vararg{Any,M}}, fillval) where {N,M} 
-    length(a) > length(b) && error("Wrong")
+    length(a) > length(b) && throw(ArgumentError("Tile dimensionality does not match grid dimensionality"))
     extenddims((a..., fillval), b, fillval)
 end
 extenddims(a::Tuple{Vararg{Any,N}}, _::Tuple{Vararg{Any,N}}, _) where {N} = a
@@ -95,8 +92,9 @@ function arraysize_and_startinds(arrays1)
     sizes = map(i -> zeros(Int, i), size(arrays1))
     for i in CartesianIndices(arrays1)
         ai = arrays1[i]
-        ai isa MissingTile && continue
-        sizecur = extenddims(size(ai), size(arrays1), 1)
+        ai isa MissingTile && (ai.size === nothing && continue)
+        size_ai = ai isa MissingTile ? ai.size : size(ai)
+        sizecur = extenddims(size_ai, size(arrays1), 1)
         foreach(sizecur, i.I, sizes) do si, ind, sizeall
             if sizeall[ind] == 0
                 #init the size
@@ -138,11 +136,8 @@ end
 function writeblock!(a::ConcatDiskArray, aout, inds::AbstractUnitRange...)
     _concat_diskarray_block_io(a, inds...) do outer_range, array_range, I
         data = view(aout, outer_range...)
-        if ismissing(I)
-            if !all(ismissing, data)
-                @warn "Trying to write data to missing array tile, skipping write"
-            end
-            return
+        if I isa MissingTile
+            throw(ArgumentError("Cannot write through a missing tile"))
         else
             writeblock!(a.parents[I], data, array_range...)
         end

--- a/src/diskarray.jl
+++ b/src/diskarray.jl
@@ -28,7 +28,7 @@ function readblock!(a::AbstractArray, aout, r...)
     if isdisk(a)
         @warn "Using fallback readblock! for array $(typeof(a)). This should not happen but there should be a custom implementation."
     end
-    copyto!(aout, CartesianIndices(aout), a, CartesianIndices(r))
+    aout .= view(a, CartesianIndices(r))
 end
 
 """

--- a/src/diskarray.jl
+++ b/src/diskarray.jl
@@ -29,6 +29,7 @@ function readblock!(a::AbstractArray, aout, r...)
         @warn "Using fallback readblock! for array $(typeof(a)). This should not happen but there should be a custom implementation."
     end
     aout .= view(a, CartesianIndices(r))
+    nothing
 end
 
 """

--- a/src/diskarray.jl
+++ b/src/diskarray.jl
@@ -23,6 +23,14 @@ The only function that should be implemented by a `AbstractDiskArray`. This func
 """
 function readblock! end
 
+function readblock!(a::AbstractArray, aout, r...)
+    # Fallback implementation for arrays that are not DiskArrays
+    if isdisk(a)
+        @warn "Using fallback readblock! for array $(typeof(a)). This should not happen but there should be a custom implementation."
+    end
+    copyto!(aout, CartesianIndices(aout), a, CartesianIndices(r))
+end
+
 """
     writeblock!(A::AbstractDiskArray, A_in, r::AbstractUnitRange...)
 

--- a/src/subarray.jl
+++ b/src/subarray.jl
@@ -44,7 +44,7 @@ function eachchunk_view(::Chunked, vv)
 end
 eachchunk_view(::Unchunked, a) = estimate_chunksize(a)
 
-# Implementaion macro
+# Implementation macro
 
 macro implement_subarray(t)
     t = esc(t)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -491,6 +491,33 @@ end
         @test slic isa Vector{Float64}
         @test slic == Float64[1, 2, 3, 4, 1, 2, 3, 4]
     end
+
+    @testset "Concat DiskArray with missing tiles" begin
+        a = zeros(Int, 3, 4)
+        b = ones(Int, 2, 4)
+        c = fill(2, 3, 5)
+        d = fill(missing, 2, 5)
+        aconc = DiskArrays.ConcatDiskArray(reshape([a, b, c, missing], 2, 2))
+        abase = [a c; b d]
+        @test all(isequal.(aconc[:, :], abase))
+        @test all(isequal.(aconc[3:4, 4:6], abase[3:4, 4:6]))
+        ch = DiskArrays.eachchunk(aconc)
+        @test ch.chunks[1] == [1:3, 4:5]
+        @test ch.chunks[2] == [1:4, 5:9]
+
+        a = ones(100, 50)
+        b = [rem(i.I[3], 5) == 0 ? missing : a for i in CartesianIndices((1, 1, 100))]
+        b[1] = missing
+        a_conc = DiskArrays.ConcatDiskArray(b)
+        ch = eachchunk(a_conc)
+        @test ch.chunks[1] == [1:100]
+        @test ch.chunks[2] == [1:50]
+        @test ch.chunks[3] === DiskArrays.RegularChunks(1, 0, 100)
+
+        @test all(isequal.(a_conc[2, 2, 1:5], [missing, 1.0, 1.0, 1.0, missing]))
+        @test all(isequal.(a_conc[end, end, 95:100], [missing, 1.0, 1.0, 1.0, 1.0, missing]))
+
+    end
 end
 
 @testset "Broadcast with length 1 and 0 final dim" begin
@@ -979,7 +1006,7 @@ end
 @testset "Padded disk arrays" begin
     M = (1:100) * (1:120)'
     A = cat(M, 2M, 3M, 4M; dims=3)
-    ch = ChunkedDiskArray(A, (128, 128, 2)) 
+    ch = ChunkedDiskArray(A, (128, 128, 2))
     pa = DiskArrays.pad(ch, ((10, 20), (30, 40), (1, 2)); fill=999)
     @test size(pa) == (130, 190, 7)
     # All outside
@@ -1009,9 +1036,9 @@ end
         @test DiskArrays._pad_offset(c1, (10, 10)) == DiskArrays.RegularChunks(10, 0, 120)
         @test DiskArrays._pad_offset(c1, (0, 0)) == c1
 
-        c2 = DiskArrays.IrregularChunks(chunksizes = [10, 10, 20, 30, 40])
+        c2 = DiskArrays.IrregularChunks(chunksizes=[10, 10, 20, 30, 40])
         #The following test would assume padding ends up in a separate chunk:
-        @test DiskArrays._pad_offset(c2, (5, 5)) == DiskArrays.IrregularChunks(chunksizes = [5, 10, 10, 20, 30, 40, 5])
+        @test DiskArrays._pad_offset(c2, (5, 5)) == DiskArrays.IrregularChunks(chunksizes=[5, 10, 10, 20, 30, 40, 5])
         @test DiskArrays._pad_offset(c2, (0, 0)) == c2
     end
 end
@@ -1054,10 +1081,10 @@ end
 end
 
 @testset "identity function" begin
-    a = ChunkedDiskArray(1:10 .> 3; chunksize=(3, ))
-	for fname in [:sum, :prod, :all, :any, :minimum, :maximum, :count]
-		@eval out = @capture_out @trace $fname($a) DiskArrays
-		@test occursin("DiskGenerator", out) == false
+    a = ChunkedDiskArray(1:10 .> 3; chunksize=(3,))
+    for fname in [:sum, :prod, :all, :any, :minimum, :maximum, :count]
+        @eval out = @capture_out @trace $fname($a) DiskArrays
+        @test occursin("DiskGenerator", out) == false
     end
     @test count(a) + count(!, a) == length(a)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -588,6 +588,48 @@ end
 
     end
 
+    @testset "ConcatDiskArray with sized MissingTile (20×40)" begin
+        # Grid with sized MissingTile contributing its explicit size
+        a = zeros(10, 20)
+        b = ones(10, 20) * 2
+        c = fill(3.0, 10, 20)
+        conc = DiskArrays.ConcatDiskArray(reshape([a, b, c, DiskArrays.MissingTile(0.0, (10, 20))], 2, 2))
+        @test size(conc) == (20, 40)
+        @test all(isequal.(conc[1:10, 1:20], a))
+        @test all(isequal.(conc[11:20, 1:20], b))
+        @test all(isequal.(conc[1:10, 21:40], c))
+        @test all(isequal.(conc[11:20, 21:40], zeros(10, 20)))
+        @test eltype(conc) == Float64
+    end
+
+    @testset "MissingTile write error" begin
+        a = zeros(10, 20)
+        b = ones(10, 20)
+        c = fill(3.0, 10, 20)
+        conc = DiskArrays.ConcatDiskArray(reshape([a, b, c, DiskArrays.MissingTile(0.0, (10, 20))], 2, 2))
+        @test_throws ArgumentError conc[15, 25] = 99.0
+    end
+
+    @testset "MissingTile grid conflict error" begin
+        # MissingTile with a size that conflicts with the grid dimensions
+        a = zeros(10, 20)
+        b = ones(10, 20)
+        c = fill(3.0, 10, 20)
+        # MissingTile claims size (5, 5) but other tiles are 10×20
+        conc = try
+            DiskArrays.ConcatDiskArray(reshape([a, b, c, DiskArrays.MissingTile(0.0, (5, 5))], 2, 2))
+            :no_error
+        catch e
+            e
+        end
+        @test conc isa ArgumentError
+    end
+
+    @testset "ConcatDiskArray with missing value error" begin
+        a = zeros(10, 20)
+        @test_throws ArgumentError DiskArrays.ConcatDiskArray(reshape([a, missing], 2, 1))
+    end
+
 end
 
 @testset "Broadcast with length 1 and 0 final dim" begin
@@ -1005,8 +1047,8 @@ struct TestArray{T,N} <: AbstractArray{T,N} end
     DiskArrays.@implement_permutedims TestArray
     DiskArrays.@implement_subarray TestArray
     @test DiskArrays.isdisk(TestArray) == true
-    DiskArrays.@implement_diskarray TestArray2
-    @test DiskArrays.isdisk(TestArray2) == true
+    DiskArrays.@implement_diskarray TestArray
+    @test DiskArrays.isdisk(TestArray) == true
 
 end
 


### PR DESCRIPTION
This PR contains a more efficient construction of `ConcatDiskArray`s and fixes #248 . In addition, it is now allowed that the array of arrays contains `missing` entries, which means that these represent tiles that contains only missings. These missing values are never allocated but will be inserted on the fly inside the `readblock!` machinery. This might make constructing mosaics of tiles less cumbersome and no need for tricks like rechunking FillArrays or similar (like in https://github.com/meggart/DiskArrayTools.jl/pull/37) just to represent missing values. 

