### PR TITLE
Add functionality to use arbitrary singular values in ConcatDiskArrays

### DIFF
--- a/src/cat.jl
+++ b/src/cat.jl
@@ -91,7 +91,7 @@ function arraysize_and_startinds(arrays1)
     sizes = map(i -> zeros(Int, i), size(arrays1))
     for i in CartesianIndices(arrays1)
         ai = arrays1[i]
-        !isa(ai, AbstractArray) && continue
+        ai isa AbstractArray || continue
         sizecur = extenddims(size(ai), size(arrays1), 1)
         foreach(sizecur, i.I, sizes) do si, ind, sizeall
             if sizeall[ind] == 0

--- a/src/cat.jl
+++ b/src/cat.jl
@@ -124,7 +124,6 @@ function readblock!(a::ConcatDiskArray, aout, inds::AbstractUnitRange...)
     # Find affected blocks and indices in blocks
     _concat_diskarray_block_io(a, inds...) do outer_range, array_range, I
         vout = view(aout, outer_range...)
-        #@show size(vout)
         if I isa CartesianIndex
             readblock!(a.parents[I], vout, array_range...)
         else 

--- a/src/cat.jl
+++ b/src/cat.jl
@@ -23,9 +23,9 @@ struct ConcatDiskArray{T,N,P,C,HC, ID} <: AbstractDiskArray{T,N}
     innerdims::Val{ID}
 end
 
-function ConcatDiskArray(arrays::AbstractArray{Union{<:AbstractArray,Missing}}; fill=missing)
+function ConcatDiskArray(arrays::AbstractArray{Union{<:AbstractArray,Missing}})
     et = Base.nonmissingtype(eltype(arrays))
-    T = promotetype(typeof(fill), eltype(et))
+    T = Union{Missing,eltype(et)}
     N = ndims(arrays)
     M = ndims(et)
     _ConcatDiskArray(arrays, T, Val(N), Val(M))
@@ -190,7 +190,7 @@ function concat_chunksize(parents)
     newchunks = map(s -> Vector{Union{RegularChunks,IrregularChunks}}(undef, s), size(parents))
     for i in CartesianIndices(parents)
         array = parents[i]
-        !isa(array,AbstractArray) && continue
+        array isa AbstractArray || continue
         chunks = eachchunk(array)
         foreach(chunks.chunks, i.I, newchunks) do c, ind, newc
             if !isassigned(newc, ind)

--- a/src/subarray.jl
+++ b/src/subarray.jl
@@ -44,7 +44,7 @@ function eachchunk_view(::Chunked, vv)
 end
 eachchunk_view(::Unchunked, a) = estimate_chunksize(a)
 
-# Implementaion macro
+# Implementation macro
 
 macro implement_subarray(t)
     t = esc(t)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -497,17 +497,18 @@ end
         b = ones(Int, 2, 4)
         c = fill(2, 3, 5)
         d = fill(0, 2, 5)
-        aconc = DiskArrays.ConcatDiskArray(reshape([a, b, c, 0], 2, 2))
+        aconc = DiskArrays.ConcatDiskArray(reshape([a, b, c, DiskArrays.MissingTile(0)], 2, 2))
         abase = [a c; b d]
         @test all(isequal.(aconc[:, :], abase))
         @test all(isequal.(aconc[3:4, 4:6], abase[3:4, 4:6]))
         ch = DiskArrays.eachchunk(aconc)
         @test ch.chunks[1] == [1:3, 4:5]
         @test ch.chunks[2] == [1:4, 5:9]
+        @test eltype(aconc) == Int
 
         a = ones(100, 50)
-        b = [rem(i.I[3], 5) == 0 ? 0 : a for i in CartesianIndices((1, 1, 100))]
-        b[1] = 0
+        b = [rem(i.I[3], 5) == 0 ? DiskArrays.MissingTile(0) : a for i in CartesianIndices((1, 1, 100))]
+        b[1] = DiskArrays.MissingTile(0)
         a_conc = DiskArrays.ConcatDiskArray(b)
         ch = eachchunk(a_conc)
         @test ch.chunks[1] == [1:100]
@@ -525,17 +526,18 @@ end
         b = ones(Int, 2, 4)
         c = fill(2, 3, 5)
         d = fill(missing, 2, 5)
-        aconc = DiskArrays.ConcatDiskArray(reshape([a, b, c, missing], 2, 2))
+        aconc = DiskArrays.ConcatDiskArray(reshape([a, b, c, DiskArrays.MissingTile(missing)], 2, 2))
         abase = [a c; b d]
         @test all(isequal.(aconc[:, :], abase))
         @test all(isequal.(aconc[3:4, 4:6], abase[3:4, 4:6]))
         ch = DiskArrays.eachchunk(aconc)
         @test ch.chunks[1] == [1:3, 4:5]
         @test ch.chunks[2] == [1:4, 5:9]
+        @test eltype(aconc) == Union{Int, Missing}
 
         a = ones(100, 50)
-        b = [rem(i.I[3], 5) == 0 ? missing : a for i in CartesianIndices((1, 1, 100))]
-        b[1] = missing
+        b = [rem(i.I[3], 5) == 0 ? DiskArrays.MissingTile(missing) : a for i in CartesianIndices((1, 1, 100))]
+        b[1] = DiskArrays.MissingTile(missing)
         a_conc = DiskArrays.ConcatDiskArray(b)
         ch = eachchunk(a_conc)
         @test ch.chunks[1] == [1:100]
@@ -544,6 +546,34 @@ end
 
         @test all(isequal.(a_conc[2, 2, 1:5], [missing, 1.0, 1.0, 1.0, missing]))
         @test all(isequal.(a_conc[end, end, 95:100], [missing, 1.0, 1.0, 1.0, 1.0, missing]))
+
+    end
+
+    @testset "Concat DiskArray with fill zero vector tiles" begin
+        a = fill([1,1], 3, 4)
+        b = fill([1,2], 2, 4)
+        c = fill([2,1], 3, 5)
+        d = fill([2,2], 2, 5)
+        aconc = DiskArrays.ConcatDiskArray(reshape([a, b, c, DiskArrays.MissingTile([2,2])], 2, 2))
+        abase = [a c; b d]
+        @test all(isequal.(aconc[:, :], abase))
+        @test all(isequal.(aconc[3:4, 4:6], abase[3:4, 4:6]))
+        ch = DiskArrays.eachchunk(aconc)
+        @test ch.chunks[1] == [1:3, 4:5]
+        @test ch.chunks[2] == [1:4, 5:9]
+        @test eltype(aconc) == Vector{Int}
+
+        a = fill([1,1], 100, 50)
+        b = [rem(i.I[3], 5) == 0 ? DiskArrays.MissingTile([0,0]) : a for i in CartesianIndices((1, 1, 100))]
+        b[1] = DiskArrays.MissingTile([0,0])
+        a_conc = DiskArrays.ConcatDiskArray(b)
+        ch = eachchunk(a_conc)
+        @test ch.chunks[1] == [1:100]
+        @test ch.chunks[2] == [1:50]
+        @test ch.chunks[3] === DiskArrays.RegularChunks(1, 0, 100)
+
+        @test all(isequal.(a_conc[2, 2, 1:5], [[0,0], [1,1],[1,1] , [1,1], [0,0]]))
+        @test all(isequal.(a_conc[end, end, 95:100], [[0,0], [1,1], [1,1], [1,1],[1,1], [0,0]]))
 
     end
 
@@ -958,8 +988,10 @@ struct TestArray{T,N} <: AbstractArray{T,N} end
     DiskArrays.@implement_array_methods TestArray
     DiskArrays.@implement_permutedims TestArray
     DiskArrays.@implement_subarray TestArray
-    DiskArrays.@implement_diskarray TestArray
     @test DiskArrays.isdisk(TestArray) == true
+    DiskArrays.@implement_diskarray TestArray2
+    @test DiskArrays.isdisk(TestArray2) == true
+
 end
 
 # issue #123


### PR DESCRIPTION
This adds the possibility to use any value instead of only missing in ConcatDiskArrays. 
We can even mix the singular values. 
