### PR TITLE
always alllow scalar indexing on CachedDiskArray

### DIFF
--- a/src/cached.jl
+++ b/src/cached.jl
@@ -50,6 +50,9 @@ function CachedDiskArray(A::AbstractArray{T,N}; maxsize=1000, mmap=false) where 
     CachedDiskArray(A, LRU{ChunkIndex{N,OffsetChunks},OffsetArray{T,N,Array{T,N}}}(; by, maxsize),mmap)
 end
 
+# Scalar indexing is allowed on CachedDiskArray
+checkscalar(::Type{Bool}, a::CachedDiskArray, i::Integer...) = true
+
 Base.parent(A::CachedDiskArray) = A.parent
 Base.size(A::CachedDiskArray) = size(parent(A))
 # TODO we need to invalidate caches when we write

--- a/src/cached.jl
+++ b/src/cached.jl
@@ -51,7 +51,8 @@ function CachedDiskArray(A::AbstractArray{T,N}; maxsize=1000, mmap=false) where 
 end
 
 # Scalar indexing is allowed on CachedDiskArray
-checkscalar(::Type{Bool}, a::CachedDiskArray, i::Integer...) = true
+checkscalar(::Type{Bool}, a::CachedDiskArray, i::Tuple) = true
+checkscalar(::Type{Bool}, a::CachedDiskArray, i::Tuple{}) = true
 
 Base.parent(A::CachedDiskArray) = A.parent
 Base.size(A::CachedDiskArray) = size(parent(A))

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -29,7 +29,7 @@ Internal `getindex` for disk arrays.
 Converts indices to ranges and calls `DiskArrays.readblock!`
 """
 function getindex_disk(a::AbstractArray, i::Union{Integer,CartesianIndex}...)
-    checkscalar(i)
+    checkscalar(a, i)
     checkbounds(a, i...)
     # Use a 1 x 1 block
     outputarray = Array{eltype(a)}(undef, map(_ -> 1, size(a))...)
@@ -44,7 +44,7 @@ function getindex_disk(a::AbstractArray, i::Union{Integer,CartesianIndex}...)
     return only(outputarray)
 end
 function getindex_disk(a::AbstractArray, i::Integer)
-    checkscalar(i)
+    checkscalar(a, i)
     checkbounds(a, i)
     # Use a 1 x 1 block
     outputarray = Array{eltype(a)}(undef, map(_ -> 1, size(a))...)
@@ -121,7 +121,7 @@ Internal `setindex!` for disk arrays.
 Converts indices to ranges and calls `DiskArrays.writeblock!`
 """
 function setindex_disk!(a::AbstractArray{T}, values::T, i...) where {T<:AbstractArray}
-    checkscalar(i)
+    checkscalar(a, i)
     # If values are not an array, wrap them in a vector
     return setindex_disk!(a, [values], i...)
 end

--- a/src/scalar.jl
+++ b/src/scalar.jl
@@ -24,14 +24,11 @@ canscalar() = ALLOWSCALAR[]
 
 # Checks if an index is scalar at all, and then if scalar indexing is allowed. 
 # Syntax as for `checkbounds`.
-checkscalar(::Type{Bool}, a::AbstractArray, i::Integer...) = checkscalar(Bool, i...)
-checkscalar(::Type{Bool}) = true # Handle 0 dimensional
-checkscalar(::Type{Bool}, I::Tuple) = checkscalar(Bool, I...)
-checkscalar(::Type{Bool}, I::Integer...) = !all(map(i -> i isa Int, I)) || canscalar()
-checkscalar(A::AbstractArray, I::Tuple) = checkscalar(A, I...)
-checkscalar(A::AbstractArray, i::Integer...) = checkscalar(Bool, A, i...) || _scalar_error()
-checkscalar(I::Tuple) = checkscalar(I...)
-checkscalar(i::Integer...) = checkscalar(Bool, i...) || _scalar_error()
+checkscalar(::Type{Bool}, A::AbstractArray, ::Tuple{}) = true # Handle 0 dimensional
+checkscalar(::Type{Bool}, A::AbstractArray, I::Tuple) = !all(map(i -> i isa Int, I)) || canscalar()
+checkscalar(::Type{Bool}, A::AbstractArray, I...) = checkscalar(Bool, A, (I...,))
+checkscalar(A::AbstractArray, I::Tuple) = checkscalar(Bool, A, I::Tuple) || _scalar_error()
+checkscalar(A::AbstractArray, I...) = checkscalar(A, I)
 
 function _scalar_error()
     return error(

--- a/src/scalar.jl
+++ b/src/scalar.jl
@@ -24,11 +24,14 @@ canscalar() = ALLOWSCALAR[]
 
 # Checks if an index is scalar at all, and then if scalar indexing is allowed. 
 # Syntax as for `checkbounds`.
+checkscalar(::Type{Bool}, a::AbstractArray, i::Integer...) = checkscalar(Bool, i...)
 checkscalar(::Type{Bool}) = true # Handle 0 dimensional
 checkscalar(::Type{Bool}, I::Tuple) = checkscalar(Bool, I...)
-checkscalar(::Type{Bool}, I...) = !all(map(i -> i isa Int, I)) || canscalar()
+checkscalar(::Type{Bool}, I::Integer...) = !all(map(i -> i isa Int, I)) || canscalar()
+checkscalar(A::AbstractArray, I::Tuple) = checkscalar(A, I...)
+checkscalar(A::AbstractArray, i::Integer...) = checkscalar(Bool, A, i...) || _scalar_error()
 checkscalar(I::Tuple) = checkscalar(I...)
-checkscalar(I...) = checkscalar(Bool, I...) || _scalar_error()
+checkscalar(i::Integer...) = checkscalar(Bool, i...) || _scalar_error()
 
 function _scalar_error()
     return error(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,14 +22,14 @@ end
 @testset "allowscalar" begin
     DiskArrays.allowscalar(false)
     @test DiskArrays.canscalar() == false
-    @test DiskArrays.checkscalar(Bool) == true # Always allowed for zero dimensional
-    @test DiskArrays.checkscalar(Bool, 1, 2, 3) == false
-    @test DiskArrays.checkscalar(Bool, 1, 2:5, :) == true
+    @test DiskArrays.checkscalar(Bool, fill(Int), ()) == true # Always allowed for zero dimensional
+    @test DiskArrays.checkscalar(Bool, zeros(5, 5, 5), (1, 2, 3)) == false
+    @test DiskArrays.checkscalar(Bool, zeros(5, 5, 5), (1, 2:5, :)) == true
     DiskArrays.allowscalar(true)
     @test DiskArrays.canscalar() == true
-    @test DiskArrays.checkscalar(Bool) == true
-    @test DiskArrays.checkscalar(Bool, 1, 2, 3) == true
-    @test DiskArrays.checkscalar(Bool, :, 2:5, 3) == true
+    @test DiskArrays.checkscalar(Bool, fill(Int), ()) == true
+    @test DiskArrays.checkscalar(Bool, zeros(5, 5, 5), (1, 2, 3)) == true
+    @test DiskArrays.checkscalar(Bool, zeros(5, 5, 5), (:, 2:5, 3)) == true
     a = AccessCountDiskArray(reshape(1:24, 2, 3, 4), chunksize=(2, 2, 2))
     @test a[1, 2, 3] == 15
     @test a[1, 2, 3, 1] == 15

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -973,6 +973,8 @@ end
         @test ca[:, 3, 1] == ch[:, 3, 1]
         @test ca[:, 200, 1] == ch[:, 200, 1]
         @test ca[200, :, 1] == ch[200, :, 1]
+        # Test scalar indexing is not checked for CachedDiskArray
+        @test ca[200, 1, 1] == ch[200, 1:1, 1][1]
     end
 end
 


### PR DESCRIPTION
I just noticed that we throw scalar indexing errors for `CachedDiskArray`, but at the same time I'm using it in some algs to make scalar indexing much less of a problem (we are mostly indexing into the cached array, not actually indexing into a disk data).

This PR allows specific array types to "turn off" the scalar indexing check, and turns them off for `CachedDiskArray` specifically.