### PR TITLE
Add 5 arg `copyto!` into `Vector` with matching type

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -23,7 +23,7 @@ function _disk_copyto!(dest, Rdest, src, Rsrc)
     view(dest, Rdest) .= view(src, Rsrc)
     return dest
 end
-function _disk_copyto_vector!(dest, dstart, src, sstart, n)
+function _disk_copyto_same_type_vector!(dest, dstart, src, sstart, n)
     if iszero(n)
         return dest
     end
@@ -33,6 +33,17 @@ function _disk_copyto_vector!(dest, dstart, src, sstart, n)
     end
     destv = view(dest, range(dstart, length=n))
     DiskArrays.readblock!(src, destv, range(sstart, length=n))
+    return dest
+end
+function _disk_copyto_vector!(dest, dstart, src, sstart, n)
+    if iszero(n)
+        return dest
+    end
+    if n < 0
+        throw(ArgumentError(LazyString("tried to copy n=",
+        n," elements, but n should be non-negative")))
+    end
+    view(dest, range(dstart, length=n)) .= view(src, range(dstart, length=n))
     return dest
 end
 
@@ -90,6 +101,15 @@ macro implement_array_methods(t)
             return $_disk_copyto!(dest, src)
         end
         function Base.copyto!(dest::Vector{T}, dstart::Integer, src::$t{T, 1}, sstart::Integer, n::Integer) where {T}
+            return $_disk_copyto_same_type_vector!(dest, dstart, src, sstart, n)
+        end
+        function Base.copyto!(dest::SubArray{T, 1, Vector{T}, <:Tuple{AbstractUnitRange}, true}, dstart::Integer, src::$t{T, 1}, sstart::Integer, n::Integer) where {T}
+            return $_disk_copyto_same_type_vector!(dest, dstart, src, sstart, n)
+        end
+        function Base.copyto!(dest::Vector, dstart::Integer, src::$t{T, 1}, sstart::Integer, n::Integer) where {T}
+            return $_disk_copyto_vector!(dest, dstart, src, sstart, n)
+        end
+        function Base.copyto!(dest::SubArray{TD, 1, Vector{TD}}, dstart::Integer, src::$t{TS, 1}, sstart::Integer, n::Integer) where {TD, TS}
             return $_disk_copyto_vector!(dest, dstart, src, sstart, n)
         end
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -35,17 +35,6 @@ function _disk_copyto_same_type_vector!(dest, dstart, src, sstart, n)
     DiskArrays.readblock!(src, destv, range(sstart, length=n))
     return dest
 end
-function _disk_copyto_vector!(dest, dstart, src, sstart, n)
-    if iszero(n)
-        return dest
-    end
-    if n < 0
-        throw(ArgumentError(LazyString("tried to copy n=",
-        n," elements, but n should be non-negative")))
-    end
-    view(dest, range(dstart, length=n)) .= view(src, range(dstart, length=n))
-    return dest
-end
 
 # Use a view for lazy reverse
 _disk_reverse(a, ::Colon) = _disk_reverse(a, ntuple(identity, ndims(a)))
@@ -105,12 +94,6 @@ macro implement_array_methods(t)
         end
         function Base.copyto!(dest::SubArray{T, 1, Vector{T}, <:Tuple{AbstractUnitRange}, true}, dstart::Integer, src::$t{T, 1}, sstart::Integer, n::Integer) where {T}
             return $_disk_copyto_same_type_vector!(dest, dstart, src, sstart, n)
-        end
-        function Base.copyto!(dest::Vector, dstart::Integer, src::$t{T, 1}, sstart::Integer, n::Integer) where {T}
-            return $_disk_copyto_vector!(dest, dstart, src, sstart, n)
-        end
-        function Base.copyto!(dest::SubArray{TD, 1, Vector{TD}}, dstart::Integer, src::$t{TS, 1}, sstart::Integer, n::Integer) where {TD, TS}
-            return $_disk_copyto_vector!(dest, dstart, src, sstart, n)
         end
 
         Base.reverse(a::$t; dims=:) = $_disk_reverse(a, dims)

--- a/src/array.jl
+++ b/src/array.jl
@@ -21,6 +21,19 @@ function _disk_copyto!(dest, Rdest, src, Rsrc)
         return dest
     end
     view(dest, Rdest) .= view(src, Rsrc)
+    return dest
+end
+function _disk_copyto_vector!(dest, dstart, src, sstart, n)
+    if iszero(n)
+        return dest
+    end
+    if n < 0
+        throw(ArgumentError(LazyString("tried to copy n=",
+        n," elements, but n should be non-negative")))
+    end
+    destv = view(dest, range(dstart, length=n))
+    DiskArrays.readblock!(src, destv, range(sstart, length=n))
+    return dest
 end
 
 # Use a view for lazy reverse
@@ -75,6 +88,9 @@ macro implement_array_methods(t)
         Base.copyto!(dest::PermutedDimsArray, src::$t) = DiskArrays._copyto!(dest, src)
         function Base.copyto!(dest::PermutedDimsArray{T,N}, src::$t{T,N}) where {T,N}
             return $_disk_copyto!(dest, src)
+        end
+        function Base.copyto!(dest::Vector{T}, dstart::Integer, src::$t{T, 1}, sstart::Integer, n::Integer) where {T}
+            return $_disk_copyto_vector!(dest, dstart, src, sstart, n)
         end
 
         Base.reverse(a::$t; dims=:) = $_disk_reverse(a, dims)

--- a/src/array.jl
+++ b/src/array.jl
@@ -23,7 +23,7 @@ function _disk_copyto!(dest, Rdest, src, Rsrc)
     view(dest, Rdest) .= view(src, Rsrc)
     return dest
 end
-function _disk_copyto_same_type_vector!(dest, dstart, src, sstart, n)
+function _disk_copyto_5arg!(dest, dstart, src, sstart, n)
     if iszero(n)
         return dest
     end
@@ -89,11 +89,11 @@ macro implement_array_methods(t)
         function Base.copyto!(dest::PermutedDimsArray{T,N}, src::$t{T,N}) where {T,N}
             return $_disk_copyto!(dest, src)
         end
-        function Base.copyto!(dest::Vector{T}, dstart::Integer, src::$t{T, 1}, sstart::Integer, n::Integer) where {T}
-            return $_disk_copyto_same_type_vector!(dest, dstart, src, sstart, n)
+        function Base.copyto!(dest::Vector, dstart::Integer, src::$t{<:Any, 1}, sstart::Integer, n::Integer)
+            return $_disk_copyto_5arg!(dest, dstart, src, sstart, n)
         end
-        function Base.copyto!(dest::SubArray{T, 1, Vector{T}, <:Tuple{AbstractUnitRange}, true}, dstart::Integer, src::$t{T, 1}, sstart::Integer, n::Integer) where {T}
-            return $_disk_copyto_same_type_vector!(dest, dstart, src, sstart, n)
+        function Base.copyto!(dest::SubArray{T, 1, Vector{T}, <:Tuple{AbstractUnitRange}, true} where {T}, dstart::Integer, src::$t{<:Any, 1}, sstart::Integer, n::Integer)
+            return $_disk_copyto_5arg!(dest, dstart, src, sstart, n)
         end
 
         Base.reverse(a::$t; dims=:) = $_disk_reverse(a, dims)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -782,11 +782,7 @@ end
         a_vec = collect(0x00:0x90)
         test_dests = [
             zero(a_vec),
-            zeros(Float32, length(a_vec)),
             view(zero(a_vec), 1:10),
-            view(zero(a_vec), 1:2:20),
-            view(zeros(Float32, length(a_vec)), 1:10),
-            view(zeros(Float32, length(a_vec)), 1:2:20),
         ]
         for x in test_dests
             local a_disk = AccessCountDiskArray(a_vec; chunksize=(15,))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -783,6 +783,7 @@ end
         test_dests = [
             zero(a_vec),
             view(zero(a_vec), 1:10),
+            zeros(length(a_vec)), # This tests type conversion
         ]
         for x in test_dests
             local a_disk = AccessCountDiskArray(a_vec; chunksize=(15,))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -770,15 +770,23 @@ end
     @test Array(a_disk) == a
     @testset "copyto" begin
         x = zero(a)
-        copyto!(x, a_disk)
+        @test copyto!(x, a_disk) === x
         @test x == a
-        copyto!(x, CartesianIndices((1:3, 1:2)), a_disk, CartesianIndices((8:10, 8:9)))
+        @test copyto!(x, CartesianIndices((1:3, 1:2)), a_disk, CartesianIndices((8:10, 8:9))) === x
         # Test copyto! with zero length index
         x_empty = Matrix{Int64}(undef, 0, 2)
         copyto!(x_empty, CartesianIndices((1:0, 1:2)), a_disk, CartesianIndices((8:7, 8:9)))
         # copyto! with different length should throw an error
         @test_throws ArgumentError copyto!(x, CartesianIndices((1:1, 1:2)), a_disk, CartesianIndices((4:6, 8:9)))
-
+        # 5 arg copyto!
+        a_vec = collect(0x00:0x90)
+        a_vec_disk = AccessCountDiskArray(a_vec; chunksize=(15,))
+        x_vec = zero(a_vec)
+        @test_throws ArgumentError copyto!(x_vec, 1, a_vec_disk, 1, -1)
+        @test copyto!(x_vec, 1, a_vec_disk, 1, 0) === x_vec
+        @test copyto!(x_vec, 6, a_vec_disk, 3, 2) === x_vec
+        @test x_vec[6] == a_vec[3]
+        @test x_vec[7] == a_vec[4]
     end
 
     @test collect(reverse(a_disk)) == reverse(a)
@@ -804,7 +812,7 @@ end
     @test vcat(a_disk, a_disk) == vcat(a, a)
     @test hcat(a_disk, a_disk) == hcat(a, a)
     @test cat(a_disk, a_disk; dims=3) == cat(a, a; dims=3)
-    @test_broken circshift(a_disk, 2) == circshift(a, 2) # This one is super weird. The size changes.
+    @test circshift(a_disk, 2) == circshift(a, 2)
 end
 
 @testset "Reshape" begin


### PR DESCRIPTION
Fixes #263

I only implemented the one-dimensional case because it wasn't obvious to me how to handle multiple dimensions, and this is all that is required for better `InputBuffers.jl` compatibility for now.

I also modified the `copyto!` function to always return `dest`, which somehow fixed the `circshift` test.